### PR TITLE
Use Bazel mirror to download externals

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ David Chen <dzc@google.com>
 Derek Perez <perezd@users.noreply.github.com>
 Derek Perez <pzd@google.com>
 Julio Merino <jmmv@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -129,7 +129,7 @@ cc_binary(
 def sass_repositories():
   native.new_http_archive(
       name = "libsass",
-      url = "https://github.com/sass/libsass/archive/3.3.0-beta1.tar.gz",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/sass/libsass/archive/3.3.0-beta1.tar.gz",
       sha256 = "6a4da39cc0b585f7a6ee660dc522916f0f417c890c3c0ac7ebbf6a85a16d220f",
       build_file_content = LIBSASS_BUILD_FILE,
       strip_prefix = "libsass-3.3.0-beta1",
@@ -137,7 +137,7 @@ def sass_repositories():
 
   native.new_http_archive(
       name = "sassc",
-      url = "https://github.com/sass/sassc/archive/3.3.0-beta1.tar.gz",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/sass/sassc/archive/3.3.0-beta1.tar.gz",
       sha256 = "87494218eea2441a7a24b40f227330877dbba75c5fa9014ac6188711baed53f6",
       build_file_content = SASSC_BUILD_FILE,
       strip_prefix = "sassc-3.3.0-beta1",


### PR DESCRIPTION
I've mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask the Bazel team for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

``` bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```
