### PR TITLE
Fix import paths to sassc

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -37,12 +37,12 @@ def _sass_binary_impl(ctx):
     options = [
         "--style={0}".format(ctx.attr.output_style),
         "--sourcemap",
+        "--load-path", ctx.configuration.bin_dir.path,
+        "--load-path", ctx.configuration.genfiles_dir.path,
     ]
 
-    # Load up all the transitive sources as dependent includes.
+    # Load up all the transitive sources
     transitive_sources = collect_transitive_sources(ctx)
-    for src in transitive_sources:
-        options += ["-I={0}".format(src)]
 
     ctx.action(
         inputs = [sassc, ctx.file.src] + list(transitive_sources),


### PR DESCRIPTION
Adds the current build target's directories for binary and generated files to
the build path. All transitive file dependencies will already be in scope under
the implicit build path of '.'.

Currently, when executing a sass_binary rule, transitive dependencies will be
passed to sassc in the textual format[1]. There are a few problems with this.

* We get the Skylark toString() repr of a build artifact
* sassc is expecting search paths, not files
* sassc expects a format ['-I', path], not ['-I={0}.format(path)']

[1] This ends up looking like:
  -I=Artifact:[/opt/app[source]]/ui/layout/_panel.scss
  -I=Artifact:[/opt/app[source]]/ui/layout/_column.scss
  etc...