### PR TITLE
Bump version in README to 0.0.2 to prepare for release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ external repositories for Sass:
 git_repository(
     name = "io_bazel_rules_sass",
     remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.1",
+    tag = "0.0.2",
 )
 
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")


### PR DESCRIPTION
There have been a few fixes checked in, and we should cut a new release.