### PR TITLE
Convert load path to point to folders rather than files

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -42,7 +42,7 @@ def _sass_binary_impl(ctx):
     # Load up all the transitive sources as dependent includes.
     transitive_sources = collect_transitive_sources(ctx)
     for src in transitive_sources:
-        options += ["-I={0}".format(src)]
+        options += ["--load-path", src.path[:-len(src.basename)]]
 
     ctx.action(
         inputs = [sassc, ctx.file.src] + list(transitive_sources),


### PR DESCRIPTION
SASS does not understand file-specific dependencies. It simply looks for all `.sass` and `.scss` files in folders found in the load path. With this change, SASS will now allow `@import` statements for dependencies.

Example:
In a build file, I generate a `SCSS` file. Before this change the only way to import it was with an absolute path, which obviously is not great for projects shared between machines.  With this change you can now `@import` the generated file by name.

```
# BUILD

# Assume this generates //bazel-genfiles/generated.scss
generate_scss(
    name = "generated",
    contents = "$super-color: red;",
)

sass_library(
    name = "generated_library",
    srcs = [ ":generated" ],
)

sass_binary(
    name = "css",
    src = "main.scss",
    deps = [ ":generated_library" ],
)
```

```
// main.scss

@import 'generated'

body {
    color: $super-color;
}
```