### PR TITLE
Add out property to sass_binary

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ Julio Merino <jmmv@google.com>
 Justine Alexandra Roberts Tunney <jart@google.com>
 Olivier Chafik <ochafik@google.com>
 Tobias Werth <twerth@google.com>
+Eric Stolten <stoltene2@gmail.com>

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Used to generate a CSS artifact from a given `src` sass file.
         <p>A unique name for this rule.</p>
         <p>
           This name will also be used as the name of the generated CSS and source map file of
-          this rule.
+          this rule unless the <code>out</code> property is used.
         </p>
       </td>
     </tr>
@@ -196,6 +196,16 @@ Used to generate a CSS artifact from a given `src` sass file.
       <td>
         <code>Main source file, required</code>
         <p>The primary Sass source file that will be compiled to CSS.</p>
+        <p>
+        <code>sass_binary</code> assumes a 1:1 mapping of src to output CSS file (and source map).
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>out</code></td>
+      <td>
+        <code>Output file to be produced, optional</code>
+        <p>The resulting CSS file that does not need to exist in the same directory as the BUILD file.</p>
         <p>
         <code>sass_binary</code> assumes a 1:1 mapping of src to output CSS file (and source map).
         </p>

--- a/examples/nested/BUILD
+++ b/examples/nested/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//sass:sass.bzl", "sass_binary")
+
+# Import our shared colors and fonts so we can generate a CSS file.
+sass_binary(
+    name = "nested",
+    src = "dir/main.scss",
+    out = "dir/main.css",
+    deps = [
+        "//examples/shared:colors",
+        "//examples/shared:fonts",
+    ],
+)

--- a/examples/nested/dir/main.scss
+++ b/examples/nested/dir/main.scss
@@ -1,0 +1,13 @@
+@import 'examples/shared/fonts';
+@import 'examples/shared/colors';
+
+html {
+  body {
+    font-family: $default-font-stack;
+
+    h1 {
+      color: $example-red;
+      font-family: $modern-font-stack;
+    }
+  }
+}

--- a/sass/test/sass_rule_test.bzl
+++ b/sass/test/sass_rule_test.bzl
@@ -39,6 +39,12 @@ def _sass_binary_test(package):
         rule = package + "/hello_world:hello_world",
     )
 
+    rule_test(
+        name = "nested_rule_test",
+        generates = ["dir/main.css", "dir/main.css.map"],
+        rule = package + "/nested:nested",
+    )
+
 def sass_rule_test(package):
     """Issue simple tests on sass rules."""
     _sass_binary_test(package)


### PR DESCRIPTION
- Closes #15 by allowing an optional property named out. If out is
  specified then it is used instead of ${name}.css.