### PR TITLE
Add support for the `sourcemap` attr to sass_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ may have dependencies (`sass_library` rules, see below).
 | `output_dir`    | Output directory, relative to this package                                    |
 | `output_name`   | Output file name, including .css extension. Defaults to `<src_name>.css`      |
 | `output_style`  | [Output style][] for the generated CSS.                                       |
+| `sourcemap`     | Whether to generate sourcemaps for the generated CSS. Defaults to True.       |
 
 [Output style]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
 

--- a/examples/hello_world/BUILD
+++ b/examples/hello_world/BUILD
@@ -11,3 +11,14 @@ sass_binary(
         "//examples/shared:fonts",
     ],
 )
+
+sass_binary(
+  name = "hello_world_no_sourcemap",
+    src = "main.scss",
+    output_name = "main-no-sourcemap.css",
+    sourcemap = False,
+    deps = [
+        "//examples/shared:colors",
+        "//examples/shared:fonts",
+    ],
+)


### PR DESCRIPTION
This attribute can be used to disable the creation of sourcemaps. It is
being added primarily for backwards compatibility with existing Google
rules.

cc @nex3 