### PR TITLE
Add scripts for buildifier and skylint

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,9 +13,9 @@ node_repositories(package_json = [])
 load("//sass:sass_repositories.bzl", "sass_repositories")
 sass_repositories()
 
-#############################################
-# Dependencies for generating documentation #
-#############################################
+#################################################
+# Dependencies for generating documentation     #
+#################################################
 
 http_archive(
     name = "bazel_skylib",
@@ -30,3 +30,42 @@ http_archive(
 )
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 skydoc_repositories()
+
+
+#################################################
+# Dependencies for bazel formatting and linting #
+#################################################
+
+BAZEL_BUILDTOOLS_VERSION = "82b21607e00913b16fe1c51bec80232d9d6de31c"
+
+# Bazel buildtools repo contains tools for BUILD file formatting ("buildifier") etc.
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % BAZEL_BUILDTOOLS_VERSION,
+    strip_prefix = "buildtools-%s" % BAZEL_BUILDTOOLS_VERSION,
+    sha256 = "edb24c2f9c55b10a820ec74db0564415c0cf553fa55e9fc709a6332fb6685eff",
+)
+
+
+IO_BAZEL_VERSION = "968f87900dce45a7af749a965b72dbac51b176b3"
+
+# Fetching the Bazel source code allows us to compile/use the Skylark linter
+http_archive(
+    name = "io_bazel",
+    url = "https://github.com/bazelbuild/bazel/archive/%s.zip" % IO_BAZEL_VERSION,
+    strip_prefix = "bazel-%s" % IO_BAZEL_VERSION,
+    sha256 = "e373d2ae24955c1254c495c9c421c009d88966565c35e4e8444c082cb1f0f48f",
+)
+
+
+# Parts of the build toolchain are written in Go, such as buildifier.
+# Bazel doesn't support transitive WORKSPACE deps, so we must repeat them here.
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
+    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()

--- a/examples/hello_world/BUILD
+++ b/examples/hello_world/BUILD
@@ -13,7 +13,7 @@ sass_binary(
 )
 
 sass_binary(
-  name = "hello_world_no_sourcemap",
+    name = "hello_world_no_sourcemap",
     src = "main.scss",
     output_name = "main-no-sourcemap.css",
     sourcemap = False,

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -1,11 +1,15 @@
 package(default_visibility = ["//visibility:public"])
+
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
-exports_files(["sass.bzl", "sass_repositories.bzl"])
+exports_files([
+    "sass.bzl",
+    "sass_repositories.bzl",
+])
 
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    node_modules = "@build_bazel_rules_sass_compiletime_deps//:node_modules",
     entry_point = "sass/sass.js",
+    node_modules = "@build_bazel_rules_sass_compiletime_deps//:node_modules",
 )

--- a/sass/docs/BUILD
+++ b/sass/docs/BUILD
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 
 skylark_doc(

--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -46,7 +46,15 @@ def _collect_transitive_sources(srcs, deps):
 
 def _sass_library_impl(ctx):
   """sass_library collects all transitive sources for given srcs and deps.
-  It doesn't execute any actions."""
+
+  It doesn't execute any actions.
+
+  Args:
+    ctx: The Bazel build context
+
+  Returns:
+    The sass_library rule.
+  """
   transitive_sources = _collect_transitive_sources(
       ctx.files.srcs, ctx.attr.deps)
   return [SassInfo(transitive_sources=transitive_sources)]
@@ -95,10 +103,20 @@ def _sass_binary_impl(ctx):
   _run_sass(ctx, ctx.file.src, ctx.outputs.css_file, map_file)
   return DefaultInfo(runfiles = ctx.runfiles(files = outputs))
 
-def _sass_binary_outputs(src, output_name, output_dir, sourcemap):
-  """Get map of sass_binary outputs, which includes the generated css file
-  and (optionally) its sourcemap.
-  Note that the arguments to this function are named after attributes on the rule."""
+def _sass_binary_outputs(output_name, output_dir, sourcemap):
+  """Get map of sass_binary outputs, including generated css and sourcemaps.
+
+  Note that the arguments to this function are named after attributes on the rule.
+
+  Args:
+    output_name: The rule's `output_name` attribute
+    output_dir: The rule's `output_dir` attribute
+    sourcemap: The rule's `sourcemap` attribute
+
+  Returns:
+    Outputs for the sass_binary
+  """
+
   output_name = output_name or "%{src}.css"
   css_file = "/".join([p for p in [output_dir, output_name] if p])
 

--- a/sass/test/sass_rule_test.bzl
+++ b/sass/test/sass_rule_test.bzl
@@ -11,26 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"Tests for Sass bzl definitions"
 
-load(
-    "//sass:sass.bzl",
-    "sass_binary",
-)
-load(
-    "@bazel_tools//tools/build_rules:test_rules.bzl",
-    "success_target",
-    "successful_test",
-    "failure_target",
-    "failed_test",
-    "assert_",
-    "strip_prefix",
-    "expectation_description",
-    "check_results",
-    "load_results",
-    "analysis_results",
-    "rule_test",
-    "file_test",
-)
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
 
 def _sass_binary_test(package):
     rule_test(

--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# rules_go (used to compile `buildifier`) still uses the deprecated APIs for
+# args.add, so we explicitly set --noincompatible_disallow_old_style_args_add
+# to avoid errors, since this project's bazelrc has this set the other way.
+bazel build --noincompatible_disallow_old_style_args_add --noshow_progress @com_github_bazelbuild_buildtools//buildifier
+
+find . -name "BUILD" -or -name "BUILD.bazel" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier

--- a/tools/skylint.sh
+++ b/tools/skylint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bazel build --noshow_progress @io_bazel//src/tools/skylark/java/com/google/devtools/skylark/skylint:Skylint
+find . -iname "*.bzl" | xargs $(bazel info bazel-bin)/external/io_bazel/src/tools/skylark/java/com/google/devtools/skylark/skylint/Skylint


### PR DESCRIPTION
I've run `buildifier` in this PR, but will fix the skylint errors in a
follow-up PR. Setting up a CI for skylint will also be a separate
undertaking, since it seems that buildkite only performs bazel commands.

cc @nex3 