### PR TITLE
Add ".cur" files to the filetype whitelist

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Compile Sass files to CSS"
 
-_FILETYPES = [".sass", ".scss", ".svg", ".png", ".gif"]
+_FILETYPES = [".sass", ".scss", ".svg", ".png", ".gif", ".cur"]
 
 # Documentation for switching which compiler is used
 _COMPILER_ATTR_DOC = """Choose which Sass compiler binary to use.


### PR DESCRIPTION
These are occasionally used to define custom cursors which are loaded
into the CSS.