### PR TITLE
Change //examples/shared:shared to //example/shared

### DIFF
--- a/examples/hello_world/BUILD
+++ b/examples/hello_world/BUILD
@@ -7,7 +7,7 @@ sass_binary(
     name = "hello_world",
     src = "main.scss",
     deps = [
-        "//examples/shared:shared",
+        "//examples/shared",
     ],
 )
 


### PR DESCRIPTION
The duplicated target name causes Google's BUILD linter to complain.