### PR TITLE
Use buildifier to format skylark files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,14 +37,14 @@ skydoc_repositories()
 # Dependencies for bazel formatting and linting #
 #################################################
 
-BAZEL_BUILDTOOLS_VERSION = "82b21607e00913b16fe1c51bec80232d9d6de31c"
+BAZEL_BUILDTOOLS_VERSION = "c39a197f7d35aebb0e0b031d728fb918f73887d6"
 
 # Bazel buildtools repo contains tools for BUILD file formatting ("buildifier") etc.
 http_archive(
     name = "com_github_bazelbuild_buildtools",
     url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % BAZEL_BUILDTOOLS_VERSION,
     strip_prefix = "buildtools-%s" % BAZEL_BUILDTOOLS_VERSION,
-    sha256 = "edb24c2f9c55b10a820ec74db0564415c0cf553fa55e9fc709a6332fb6685eff",
+    sha256 = "30c8e027d0ed7843651fbe2dbb6338171c963ba1184a7bce802ae4a30e223fd4",
 )
 
 

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -16,11 +16,11 @@
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 def sass_repositories():
-  """Set up environment for Sass compiler.
-  """
+    """Set up environment for Sass compiler.
+    """
 
-  yarn_install(
-      name = "build_bazel_rules_sass_compiletime_deps",
-      package_json = "@io_bazel_rules_sass//sass:package.json",
-      yarn_lock = "@io_bazel_rules_sass//sass:yarn.lock",
-  )
+    yarn_install(
+        name = "build_bazel_rules_sass_compiletime_deps",
+        package_json = "@io_bazel_rules_sass//sass:package.json",
+        yarn_lock = "@io_bazel_rules_sass//sass:yarn.lock",
+    )

--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -5,4 +5,4 @@
 # to avoid errors, since this project's bazelrc has this set the other way.
 bazel build --noincompatible_disallow_old_style_args_add --noshow_progress @com_github_bazelbuild_buildtools//buildifier
 
-find . -name "BUILD" -or -name "BUILD.bazel" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier
+find . -name "BUILD" -or -name "BUILD.bazel" -or -iname "*.bzl" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier


### PR DESCRIPTION
cc @nex3 

Buildifier only very recently added (alpha) support for formatting skylark: https://github.com/bazelbuild/buildtools/releases/tag/0.12.0