### PR TITLE
Add runfiles to sass_library's DefaultInfo provider

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -63,7 +63,10 @@ def _sass_library_impl(ctx):
     )
     return [
         SassInfo(transitive_sources = transitive_sources),
-        DefaultInfo(files = transitive_sources),
+        DefaultInfo(
+            files = transitive_sources,
+            runfiles = ctx.runfiles(transitive_files = transitive_sources),
+        ),
     ]
 
 def _run_sass(ctx, input, css_output, map_output = ""):


### PR DESCRIPTION
This allows a sass_library target to be used as data for certain
rules (like native.sh_binary) and have its sources be available.