### PR TITLE
Properly disable source maps with sourcemap = False

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -25,3 +25,6 @@ platforms:
     - "-//sass/docs"
     test_targets:
     - "//..."
+    # file_test is broken on Windows, see
+    # https://github.com/bazelbuild/bazel/issues/6122
+    - "-//sass/test:no_sourcemap_file_test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,6 +24,8 @@ platforms:
     # https://github.com/bazelbuild/skydoc/issues/58
     - "-//sass/docs"
     test_targets:
+    # Escape hyphens on later args
+    - "--"
     - "//..."
     # file_test is broken on Windows, see
     # https://github.com/bazelbuild/bazel/issues/6122

--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -79,8 +79,8 @@ def _run_sass(ctx, input, css_output, map_output = ""):
     # Flags (see https://github.com/sass/dart-sass/blob/master/lib/src/executable/options.dart)
     args.add_joined(["--style", ctx.attr.output_style], join_with = "=")
 
-    if ctx.attr.sourcemap:
-        args.add("--source-map")
+    if not ctx.attr.sourcemap:
+        args.add("--no-source-map")
 
     # Sources for compilation may exist in the source tree, in bazel-bin, or bazel-genfiles.
     for prefix in [".", ctx.var["BINDIR"], ctx.var["GENDIR"]]:

--- a/sass/test/sass_rule_test.bzl
+++ b/sass/test/sass_rule_test.bzl
@@ -13,13 +13,26 @@
 # limitations under the License.
 "Tests for Sass bzl definitions"
 
-load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test")
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "rule_test", "file_test")
 
 def _sass_binary_test(package):
     rule_test(
         name = "hello_world_rule_test",
         generates = ["main.css", "main.css.map"],
         rule = package + "/hello_world:hello_world",
+    )
+
+    rule_test(
+        name = "no_sourcemap_rule_test",
+        generates = ["main-no-sourcemap.css"],
+        rule = package + "/hello_world:hello_world_no_sourcemap",
+    )
+
+    file_test(
+        name = "no_sourcemap_file_test",
+        file = package + "/hello_world:hello_world_no_sourcemap",
+        regexp = r"sourceMappingURL=",
+        matches = 0,
     )
 
     rule_test(


### PR DESCRIPTION
We had been following LibSass's lead by passing --source-map when
sourcemap = True. However, Dart Sass enables source map generation by
default, so we instead need to pass --no-source-map when sourcemap =
False.