### PR TITLE
Re-apply rules_go update to 0.16.0.

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -58,9 +58,8 @@ def rules_sass_dev_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "io_bazel_rules_go",
-        urls = ["https://github.com/bazelbuild/rules_go/archive/cbc1e32fba771845305f15e341fa26595d4a136d.zip"],
-        strip_prefix = "rules_go-cbc1e32fba771845305f15e341fa26595d4a136d",
-        sha256 = "d02b1d8d11fb67fb1e451645256e58a1542170eedd6e2ba160c8540c96f659da",
+        sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
+        url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
     )
 
     # Bazel buildtools repo contains tools for BUILD file formatting ("buildifier") etc.


### PR DESCRIPTION
Still needed as part of bazelbuild/bazel#6283.

This was originally fixed in c6344f50f9d541fcf6d0064c28c8f70860941551, but accidentally reverted in 8b61ad6953fde55031658e1731c335220f881369.