### PR TITLE
Set use_default_shell_env

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -100,6 +100,7 @@ def _run_sass(ctx, input, css_output, map_output = None):
                  list(_collect_transitive_sources([input], ctx.attr.deps)),
         arguments = [args],
         outputs = [css_output, map_output] if map_output else [css_output],
+	use_default_shell_env = True,
     )
 
 def _sass_binary_impl(ctx):


### PR DESCRIPTION
The `SassCompiler` action calls a Bash script which in turn assumes
`grep`, `cut`, `dirname` and other commands to be available in the
`PATH`. But we can't rely on that to be true without
`use_default_shell_env = True`. That's because without this flag,
shell scripts use Bash's default `PATH` (since `/usr/bin/env -` clears
the entire environment). That default `PATH` will be different on
different platforms, and is not guaranteed to contain all the shell
commands this script expects to be able to call. Indeed, on NixOS the
default `PATH` for Bash is `/no-such-path`.

If turning on `use_default_shell_env` makes your nervous, it
shouldn't. According to https://github.com/bazelbuild/bazel/pull/6263,
`--experimental_strict_action_env` will become the default in Bazel
v0.20. This means that the default env will be restricted, standard
and small. (So this shouldn't hurt hermeticity - actually it should
help it.)