### PR TITLE
docs: readme shows version that does not come with the new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ published versions:
 http_archive(
     name = "io_bazel_rules_sass",
     # Make sure to check for the latest version when you install
-    url = "https://github.com/bazelbuild/rules_sass/archive/1.14.3.zip",
-    strip_prefix = "rules_sass-1.14.3",
-    sha256 = "058912f6035fe8a61fc602d19cbf95e1ab668a90b2c813ef6ae5dce95458c434",
+    url = "https://github.com/bazelbuild/rules_sass/archive/1.15.2.zip",
+    strip_prefix = "rules_sass-1.15.2",
+    sha256 = "96cedd370d8b87759c8b4a94e6e1c3bef7c17762770215c65864d9fba40f07cf",
 )
 
 # Fetch required transitive dependencies. This is an optional step because you


### PR DESCRIPTION
Currently the readme shows a version of the Bazel sass rules that does not include the changes from https://github.com/bazelbuild/rules_sass/commit/8b61ad6953fde55031658e1731c335220f881369.

This is problematic because the `README.md` currently shows the usage of "new" API while it proposes downloading `1.14.3` which does not include the new API changes.

Fixes #56

cc. @jelbourn 