### PR TITLE
docs: update the hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ rules_sass_dependencies()
 # Setup repositories which are needed for the Sass rules.
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
+
+# Setup the NodeJS toolchain
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+node_repositories()
 ```
 
 ## Basic Example


### PR DESCRIPTION
[`node_repositories`](https://github.com/bazelbuild/rules_nodejs/blob/838d8abb749382916b0d2ebd15caa5b3bbb52dc6/internal/node/node_repositories.bzl#L469-L605) should be invoked once the `rules_nodejs` dependency is available. Otherwise, bazel throws the error: 

```
ERROR: Analysis of target '//hello_world:hello_world' failed; build aborted: no such package '@nodejs//': The repository could not be resolved
```