### PR TITLE
Reinstate multi_sass_binary_rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Rules
 * [sass_binary]()
 * [sass_library]()
+* [multi_sass_binary]()
 
 ## Overview
 These build rules are used for building [Sass][sass] projects with Bazel.
@@ -138,7 +139,7 @@ INFO: Elapsed time: 1.911s, Critical Path: 0.01s
 ### sass_binary
 
 ```py
-sass_binary(name, src, deps=[], output_style="compressed", include_paths=[], output_dir=".", output_name=<src_filename.css>)
+sass_binary(name, src, deps=[], include_paths=[], output_dir=".", output_name=<src_filename.css>, output_style="compressed", sourcemap=True)
 ```
 
 `sass_binary` compiles a single CSS output from a single Sass entry-point file. The entry-point file
@@ -181,3 +182,41 @@ any outputs.
 | `name`    | Unique name for this rule (required)                                                |
 | `srcs`    | Sass files included in this library. Each file should start with an underscore      |
 | `deps`    | Dependencies for the `src`. Each dependency is a `sass_library`                     |
+
+### multi_sass_binary
+
+```py
+multi_sass_binary(name, srcs=[], output_style="compressed", sourcemap=True)
+```
+
+`multi_sass_binary` compiles a list of Sass files and outputs the corresponding
+CSS files and optional sourcemaps. Output is omitted for filenames that start
+with underscore "_".
+
+
+:warning: **WARNING**: This rule does a global compilation, and thus any change in the sources
+will trigger a build for **all** files. It is inefficient. Always prefer
+`sass_binary` and provide strict dependencies for most efficient compilation.
+This rule is also not used internally at Google.
+
+
+#### Output targets
+
+The following pair of files is generated for _each_ file in `srcs`.
+
+| Label              | Description                                                                  |
+|--------------------|------------------------------------------------------------------------------|
+| <filename>.css     | The generated CSS output                                                     |
+| <filename>.css.map | The [source map][] that can be used to debug the Sass source in-browser      |
+
+[source map]: https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps
+
+
+| Attribute       | Description                                                                   |
+|-----------------|-------------------------------------------------------------------------------|
+| `name`          | Unique name for this rule (required)                                          |
+| `srcs`          | A list of Sass files (required).                                              |
+| `output_style`  | [Output style][] for the generated CSS.                                       |
+| `sourcemap`     | Whether to generate sourcemaps for the generated CSS. Defaults to True.       |
+
+[Output style]: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style

--- a/defs.bzl
+++ b/defs.bzl
@@ -15,12 +15,19 @@
 """ Public API is re-exported here."""
 
 load("//sass:sass_repositories.bzl", _sass_repositories = "sass_repositories")
-load("//sass:sass.bzl", _SassInfo = "SassInfo", _sass_binary = "sass_binary", _sass_library = "sass_library")
+load(
+  "//sass:sass.bzl",
+  _SassInfo = "SassInfo",
+  _sass_binary = "sass_binary",
+  _sass_library = "sass_library",
+  _multi_sass_binary = "multi_sass_binary",
+)
 
 sass_repositories = _sass_repositories
 
 sass_library = _sass_library
 sass_binary = _sass_binary
+multi_sass_binary = _multi_sass_binary
 
 # Expose the SassInfo provider so that people can make their own custom rules
 # that expose sass library outputs.

--- a/examples/demo/BUILD.bazel
+++ b/examples/demo/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//:defs.bzl", "multi_sass_binary")
+
+multi_sass_binary(
+  name = "demo",
+  srcs = glob(["**/*.scss"]),
+)

--- a/examples/demo/_styles.scss
+++ b/examples/demo/_styles.scss
@@ -1,0 +1,6 @@
+$example-blue: #00f;
+$example-red: #f00;
+$example-green: #008000;
+
+$default-font-stack: Cambria, "Hoefler Text", Utopia, "Liberation Serif", "Nimbus Roman No9 L Regular", Times, "Times New Roman", serif;
+$modern-font-stack: Constantia, "Lucida Bright", Lucidabright, "Lucida Serif", Lucida, "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;

--- a/examples/demo/app/app.component.scss
+++ b/examples/demo/app/app.component.scss
@@ -1,0 +1,6 @@
+@import 'styles';
+
+h1 {
+  color: $example-red;
+  font-family: $modern-font-stack;
+}

--- a/examples/demo/app/widget/widget.component.scss
+++ b/examples/demo/app/widget/widget.component.scss
@@ -1,0 +1,12 @@
+@import 'styles';
+
+h1 {
+  color: $example-blue;
+  font-family: $default-font-stack;
+}
+
+
+h2 {
+  color: $example-green;
+  font-family: $modern-font-stack;
+}

--- a/sass/test/sass_rule_test.bzl
+++ b/sass/test/sass_rule_test.bzl
@@ -41,6 +41,19 @@ def _sass_binary_test(package):
         rule = package + "/nested:nested",
     )
 
+def _multi_sass_binary_test(package):
+  rule_test(
+    name = "demo_test",
+    generates = [
+      "app/app.component.css",
+      "app/app.component.css.map",
+      "app/widget/widget.component.css",
+      "app/widget/widget.component.css.map",
+    ],
+    rule = package + "/demo:demo",
+  )
+
 def sass_rule_test(package):
     """Issue simple tests on sass rules."""
     _sass_binary_test(package)
+    _multi_sass_binary_test(package)


### PR DESCRIPTION
This commit restores `multi_sass_binary` rule.
For discussion see https://github.com/bazelbuild/rules_sass/issues/72

PR Closes #72