### PR TITLE
Wire the "--embed-sources" flag through Sass bazel rules.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,4 +29,6 @@ platforms:
     - "//..."
     # file_test is broken on Windows, see
     # https://github.com/bazelbuild/bazel/issues/6122
+    - "-//sass/test:hello_world_file_test"
+    - "-//sass/test:sourcemap_embed_sources_file_test"
     - "-//sass/test:no_sourcemap_file_test"

--- a/examples/hello_world/BUILD
+++ b/examples/hello_world/BUILD
@@ -12,6 +12,16 @@ sass_binary(
 )
 
 sass_binary(
+    name = "hello_world_sourcemap_embed_sources",
+    src = "main.scss",
+    output_name = "main-sourcemap-embed-sources.css",
+    sourcemap_embed_sources = True,
+    deps = [
+        "//examples/shared",
+    ],
+)
+
+sass_binary(
     name = "hello_world_no_sourcemap",
     src = "main.scss",
     output_name = "main-no-sourcemap.css",

--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -81,6 +81,8 @@ def _run_sass(ctx, input, css_output, map_output = None):
 
     if not ctx.attr.sourcemap:
         args.add("--no-source-map")
+    elif ctx.attr.sourcemap_embed_sources:
+        args.add("--embed-sources")
 
     # Sources for compilation may exist in the source tree, in bazel-bin, or bazel-genfiles.
     for prefix in [".", ctx.var["BINDIR"], ctx.var["GENDIR"]]:
@@ -177,7 +179,11 @@ _sass_binary_attrs = {
     ),
     "sourcemap": attr.bool(
         default = True,
-        doc = "Whether sourcemaps should be emitted.",
+        doc = "Whether source maps should be emitted.",
+    ),
+    "sourcemap_embed_sources": attr.bool(
+        default = False,
+        doc = "Whether to embed source file contents in source maps.",
     ),
     "include_paths": attr.string_list(
         doc = "Additional directories to search when resolving imports",

--- a/sass/test/sass_rule_test.bzl
+++ b/sass/test/sass_rule_test.bzl
@@ -22,6 +22,29 @@ def _sass_binary_test(package):
         rule = package + "/hello_world:hello_world",
     )
 
+    file_test(
+        name = "hello_world_file_test",
+        file = package + "/hello_world:main.css.map",
+        regexp = "\"sourcesContent\":",
+        matches = 0,
+    )
+
+    rule_test(
+        name = "sourcemap_embed_sources_rule_test",
+        generates = [
+            "main-sourcemap-embed-sources.css",
+            "main-sourcemap-embed-sources.css.map",
+        ],
+        rule = package + "/hello_world:hello_world_sourcemap_embed_sources",
+    )
+
+    file_test(
+        name = "sourcemap_embed_sources_file_test",
+        file = package + "/hello_world:main-sourcemap-embed-sources.css.map",
+        regexp = "\"sourcesContent\":",
+        matches = 1,
+    )
+
     rule_test(
         name = "no_sourcemap_rule_test",
         generates = ["main-no-sourcemap.css"],


### PR DESCRIPTION
--embed-sources embeds source file contents in source maps.