### PR TITLE
Avoid iteration over a depset

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -235,7 +235,7 @@ def _multi_sass_binary_impl(ctx):
     The multi_sass_binary rule.
   """
 
-  inputs = depset([f for t in ctx.attr.srcs for f in t.files])
+  inputs = ctx.files.srcs
   outputs = []
   # Every non-partial Sass file will produce one CSS output file and,
   # optionally, one sourcemap file.


### PR DESCRIPTION
With this change, the code works with Bazel
`--incompatible_depset_is_not_iterable` flag.

Fixes #79 