### PR TITLE
Remove unnecessary semicolons in WORKSPACE file. 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ workspace(name = "io_bazel_rules_sass")
 
 load("//:package.bzl", "rules_sass_dependencies", "rules_sass_dev_dependencies")
 
-rules_sass_dependencies();
-rules_sass_dev_dependencies();
+rules_sass_dependencies()
+rules_sass_dev_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 node_repositories()


### PR DESCRIPTION
It is not a valid syntax in bazel