### PR TITLE
Update to nodejs rules 0.30.1

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,9 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        url = "https://github.com/bazelbuild/rules_nodejs/archive/0.16.4.zip",
-        strip_prefix = "rules_nodejs-0.16.4",
-        sha256 = "e8704168f9aef4dad828cb8fd39ce0e84c5e8cfa2ab5001b41f2e8b4b04c5147",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/0.30.1/rules_nodejs-0.30.1.tar.gz",
+        sha256 = "abcf497e89cfc1d09132adfcd8c07526d026e162ae2cb681dcb896046417ce91",
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -24,4 +24,8 @@ def sass_repositories():
         name = "build_bazel_rules_sass_deps",
         package_json = "@io_bazel_rules_sass//sass:package.json",
         yarn_lock = "@io_bazel_rules_sass//sass:yarn.lock",
+        # Do not symlink node_modules as when used in downstream repos we should not create
+        # node_modules folders in the @io_bazel_rules_sass external repository. This is
+        # not supported by managed_directories.
+        symlink_node_modules = False,
     )


### PR DESCRIPTION
Update to nodejs rules 0.30.1.

Adds `symlink_node_modules = False` to @build_bazel_rules_sass_deps yarn_install as this is required when that yarn_install is run downstream for users of rules_sass with rules_nodejs 0.30.0+.

Angular and other rules_nodejs users will need this update downstream as it makes rules_sass compatible with rules_nodejs 0.30.0+.