### PR TITLE
Update to nodejs rules 0.31.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ rules_sass_dependencies()
 # Setup repositories which are needed for the Sass rules.
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
-
-# Setup the NodeJS toolchain
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
 ```
 
 ## Basic Example

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,6 @@ load("//:package.bzl", "rules_sass_dependencies", "rules_sass_dev_dependencies")
 rules_sass_dependencies()
 rules_sass_dev_dependencies()
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
-
 load("//:defs.bzl", "sass_repositories")
 sass_repositories()
 

--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/0.30.1/rules_nodejs-0.30.1.tar.gz",
-        sha256 = "abcf497e89cfc1d09132adfcd8c07526d026e162ae2cb681dcb896046417ce91",
+        sha256 = "e04a82a72146bfbca2d0575947daa60fda1878c8d3a3afe868a8ec39a6b968bb",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.31.1/rules_nodejs-0.31.1.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -10,7 +10,7 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "sass/sass.js",
+    entry_point = "@build_bazel_rules_sass_deps//node_modules/sass:sass.js",
     install_source_map_support = False,
     data = [
         "@build_bazel_rules_sass_deps//sass",

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -14,11 +14,14 @@
 
 "Install Sass toolchain dependencies"
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install", "check_rules_nodejs_version")
 
 def sass_repositories():
     """Set up environment for Sass compiler.
     """
+
+    # 0.31.1: entry_point attribute of rules_nodejs is now a label
+    check_rules_nodejs_version("0.31.1")
 
     yarn_install(
         name = "build_bazel_rules_sass_deps",


### PR DESCRIPTION
nodejs_binary entry_point is now a label. See release notes https://github.com/bazelbuild/rules_nodejs/releases/tag/0.31.0 for more info.

This commit is a pre-req to bazelbuild/rules_nodejs#777