### PR TITLE
Support bazel persistent worker

### DIFF
--- a/sass/BUILD
+++ b/sass/BUILD
@@ -10,9 +10,11 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "@build_bazel_rules_sass_deps//:node_modules/sass/sass.js",
+    entry_point = "sass_wrapper",
     install_source_map_support = False,
     data = [
+        ":sass_wrapper.js",
         "@build_bazel_rules_sass_deps//sass",
+        "@build_bazel_rules_sass_deps//@bazel/worker",
     ],
 )

--- a/sass/package.json
+++ b/sass/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@bazel/worker": "latest",
     "sass": "1.22.9"
   }
 }

--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -94,6 +94,8 @@ def _run_sass(ctx, input, css_output, map_output = None):
     # Note that the sourcemap is implicitly written to a path the same as the
     # css with the added .map extension.
     args.add_all([input.path, css_output.path])
+    args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
 
     ctx.actions.run(
         mnemonic = "SassCompiler",
@@ -103,6 +105,7 @@ def _run_sass(ctx, input, css_output, map_output = None):
         arguments = [args],
         outputs = [css_output, map_output] if map_output else [css_output],
         use_default_shell_env = True,
+        execution_requirements = {"supports-workers": "1"},
     )
 
 def _sass_binary_impl(ctx):
@@ -268,6 +271,8 @@ def _multi_sass_binary_impl(ctx):
     args.add("--no-source-map")
 
   args.add(root_dir + ":" + ctx.bin_dir.path + '/' + root_dir)
+  args.use_param_file("@%s", use_always = True)
+  args.set_param_file_format("multiline")
 
   if inputs:
     ctx.actions.run(

--- a/sass/sass_wrapper.js
+++ b/sass/sass_wrapper.js
@@ -9,6 +9,7 @@
  * It can also be invoked with an argument file to run once and exit.
  */
 "use strict";
+
 const {debug, runAsWorker, runWorkerLoop} = require('@bazel/worker');
 const sass = require('sass');
 const fs = require('fs');
@@ -21,12 +22,11 @@ if (runAsWorker(args)) {
   // is waiting for async callbacks from node.
 } else {
   debug('Running a single build...');
-  if (args.length === 0) {
-    throw new Error('Not enough arguments');
-  }
+  if (args.length === 0) throw new Error('Not enough arguments');
   if (args.length !== 1) {
     throw new Error('Expected one argument: path to flagfile');
   }
+
   // Bazel worker protocol expects the only arg to be @<path_to_flagfile>.
   // When we are running a single build, we remove the @ prefix and read the list 
   // of actual arguments line by line.
@@ -34,4 +34,5 @@ if (runAsWorker(args)) {
   const configContent = fs.readFileSync(configFile, 'utf8').trim();
   sass.run_(configContent.split('\n'));
 }
+
 process.exitCode = 0;

--- a/sass/sass_wrapper.js
+++ b/sass/sass_wrapper.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ * 
+ * A Sass compiler wrapper that supports bazel persistent worker protocol.
+ *
+ * Bazel can spawn a persistent worker process that handles multiple invocations.
+ * It can also be invoked with an argument file to run once and exit.
+ */
+"use strict";
+const {debug, runAsWorker, runWorkerLoop} = require('@bazel/worker');
+const sass = require('sass');
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+if (runAsWorker(args)) {
+  debug('Starting Sass compiler persistent worker...');
+  runWorkerLoop(args => sass.run_(args));
+  // Note: intentionally don't process.exit() here, because runWorkerLoop
+  // is waiting for async callbacks from node.
+} else {
+  debug('Running a single build...');
+  if (args.length === 0) {
+    throw new Error('Not enough arguments');
+  }
+  if (args.length !== 1) {
+    throw new Error('Expected one argument: path to flagfile');
+  }
+  // Bazel worker protocol expects the only arg to be @<path_to_flagfile>.
+  // When we are running a single build, we remove the @ prefix and read the list 
+  // of actual arguments line by line.
+  const configFile = args[0].replace(/^@+/, '');
+  const configContent = fs.readFileSync(configFile, 'utf8').trim();
+  sass.run_(configContent.split('\n'));
+}
+process.exitCode = 0;

--- a/sass/yarn.lock
+++ b/sass/yarn.lock
@@ -2,18 +2,83 @@
 # yarn lockfile v1
 
 
+"@bazel/worker@latest":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-0.36.0.tgz#817f480c3635df9d21422448f1654d0dad879344"
+  integrity sha512-EZVP0bZYmCXd7ZflQhenjyWJC3g/0SP+rpAK+BYKTcpSkSrhXR9KWm8ecwiQPoxCZ+8xTwH3T1xT+KFkVgISkw==
+  dependencies:
+    protobufjs "6.8.8"
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+  integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
+"@types/node@^10.1.0":
+  version "10.14.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.15.tgz#e8f7729b631be1b02ae130ff0b61f3e018000640"
+  integrity sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==
+
 anymatch@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.0.2.tgz#ddb3a8495d44875423af7b919aace11e91732a41"
-  integrity sha512-rUe9SxpRQlVg4EM8It7JMNWWYHAirTPpbTuvaSKybb5IejNgWB3PGBBX9rrPKDx2pM/p3Wh+7+ASaWRyyAbxmQ==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.0.3.tgz#2fb624fe0e84bccab00afee3d0006ed310f22f09"
+  integrity sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-async-each@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
-  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 binary-extensions@^2.0.0:
   version "2.0.0"
@@ -28,18 +93,17 @@ braces@^3.0.2:
     fill-range "^7.0.1"
 
 "chokidar@>=2.0.0 <4.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.0.1.tgz#98fe9aa476c55d9aea7841d6325ffdb30e95b40c"
-  integrity sha512-2ww34sJWehnbpV0Q4k4V5Hh7juo7po6z7LUWkcIQnSGN1lHOL8GGtLtfwabKvLFQw/hbSUQ0u6V7OgGYgBzlkQ==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.0.2.tgz#0d1cd6d04eb2df0327446188cd13736a3367d681"
+  integrity sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==
   dependencies:
     anymatch "^3.0.1"
-    async-each "^1.0.3"
     braces "^3.0.2"
     glob-parent "^5.0.0"
     is-binary-path "^2.1.0"
     is-glob "^4.0.1"
     normalize-path "^3.0.0"
-    readdirp "^3.0.2"
+    readdirp "^3.1.1"
   optionalDependencies:
     fsevents "^2.0.6"
 
@@ -86,6 +150,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -96,10 +165,29 @@ picomatch@^2.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
-readdirp@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.0.2.tgz#cba63348e9e42fc1bd334b1d2ef895b6a043cbd6"
-  integrity sha512-LbyJYv48eywrhOlScq16H/VkCiGKGPC2TpOdZCJ7QXnYEjn3NN/Oblh8QEU3vqfSRBB7OGvh5x45NKiVeNujIQ==
+protobufjs@6.8.8:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
+  integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+readdirp@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.1.2.tgz#fa85d2d14d4289920e4671dead96431add2ee78a"
+  integrity sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==
   dependencies:
     picomatch "^2.0.4"
 


### PR DESCRIPTION
Create a thin wrapper of sass compiler that supports persistent worker.

Tested via https://github.com/alexeagle/rules_sass_repro
The repro contains 40 empty sass files
Running the sass compiler on them should be fast

bazel build :all takes ~40s
bazel build --strategy=SassCompiler=worker :all takes ~1s