### PR TITLE
Remove --incompatible_disallow_old_style_args_add from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,2 @@
-# Disable the deprecated use of "args.add" to align with settings inside Google.
-build --incompatible_disallow_old_style_args_add
-
 # By default, failing tests don't print any output, it goes to the log file
 test --test_output=errors


### PR DESCRIPTION
This option has been flipped and is now removed from Bazel. This fixes the Bazel CI downstream pipeline https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1272#15857600-41ab-4f3c-bc27-3289bbe21cfc