### PR TITLE
Allow error messages to be reported in Sass workers

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "a54b2511d6dae42c1f7cdaeb08144ee2808193a088004fc3b464a04583d5aa2e",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.42.3/rules_nodejs-0.42.3.tar.gz"],
+        sha256 = "0f2de53628e848c1691e5729b515022f5a77369c76a09fbe55611e12731c90e3",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.1/rules_nodejs-2.0.1.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -10,10 +10,11 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "sass_wrapper",
     data = [
         ":sass_wrapper.js",
-        "@build_bazel_rules_sass_deps//sass",
         "@build_bazel_rules_sass_deps//@bazel/worker",
+        "@build_bazel_rules_sass_deps//minimist",
+        "@build_bazel_rules_sass_deps//sass",
     ],
+    entry_point = "sass_wrapper.js",
 )

--- a/sass/package.json
+++ b/sass/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@bazel/worker": "latest",
+    "minimist": "1.2.5",
     "sass": "1.26.9"
   }
 }

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -22,7 +22,8 @@ def sass_repositories():
 
     # 0.31.1: entry_point attribute of rules_nodejs is now a label
     # 0.32.0: @npm//node_modules/foobar:foobar.js labels changed to @npm//:node_modules/foobar/foobar.js with fix for bazelbuild/rules_nodejs#802.
-    check_rules_nodejs_version("0.32.0")
+    # 2.0.1: run_node exported as part of its external API
+    check_rules_nodejs_version("2.0.1")
 
     yarn_install(
         name = "build_bazel_rules_sass_deps",

--- a/sass/yarn.lock
+++ b/sass/yarn.lock
@@ -155,6 +155,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+minimist@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"


### PR DESCRIPTION
This upgrades the rules_nodejs version to 2.0.1, enabling us to make use
of the `run_node` functions provided there.

The sass_wrapper.js is modified to directly translate argv into object
arguments that are passed to the public API that is part of `sass`.

Minimist is also added as a dependency.

Fixes #96.