### PR TITLE
prepare for breaking change in rules_nodejs

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "84abf7ac4234a70924628baa9a73a5a5cbad944c4358cf9abdb4aab29c9a5b77",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.7.0/rules_nodejs-1.7.0.tar.gz"],
+        sha256 = "121f17d8b421ce72f3376431c3461cd66bfe14de49059edc7bb008d5aebd16be",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.3.1/rules_nodejs-2.3.1.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -16,4 +16,10 @@ nodejs_binary(
         "@build_bazel_rules_sass_deps//sass",
         "@build_bazel_rules_sass_deps//@bazel/worker",
     ],
+    # Opt-in to the patched require() function like google3 has
+    # rules_nodejs 3.0 will flip the default for this flag which breaks rules_sass users
+    templated_args = [
+        "--nobazel_node_patches",
+        "--bazel_patch_module_resolver",
+    ],
 )

--- a/sass/package.json
+++ b/sass/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@bazel/worker": "latest",
+    "@bazel/worker": "2.3.1",
     "sass": "1.29.0"
   }
 }

--- a/sass/yarn.lock
+++ b/sass/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/worker@latest":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-0.37.0.tgz#36354ba28389e9e0ebf03ec2a9cbf4e7b02d5cba"
-  integrity sha512-uEXbehz5dcO/LErfjIx0I2nmmiWWeK0pOeMPFYpMx7oiuFxEIF0porTsJL5Y5kTHP5/6U15in04IDWn/QJdQUw==
+"@bazel/worker@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-2.3.1.tgz#da0e02c1c9239788a1cb2be99224d0cdae226760"
+  integrity sha512-4iN6bWrZivT2U5x63t8XJrIQlizkGnxldFdCX5B1YKBrkPUmMq7ffG00Yi+Ahg4WWpCt2TwLoToZMPxz/6tCtw==
   dependencies:
     protobufjs "6.8.8"
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_nodejs/issues/2125 is going to turn off the patching of the require() function by default. The reason is that it breaks compatibility with many node programs. However rules_sass depends on this, and also has at least conceptual sharing with google3 which uses the patched require() as well.

This change is a no-op for rules_nodejs 2.x where the default is true, but is required with rules_nodejs 3.0 where it will be false.