### PR TITLE
update to rules_nodejs 3.0.0

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "121f17d8b421ce72f3376431c3461cd66bfe14de49059edc7bb008d5aebd16be",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.3.1/rules_nodejs-2.3.1.tar.gz"],
+        sha256 = "6142e9586162b179fdd570a55e50d1332e7d9c030efd853453438d607569721d",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.0.0/rules_nodejs-3.0.0.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/package.json
+++ b/sass/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@bazel/worker": "2.3.1",
+    "@bazel/worker": "3.0.0",
     "sass": "1.30.0"
   }
 }

--- a/sass/yarn.lock
+++ b/sass/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/worker@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-2.3.1.tgz#da0e02c1c9239788a1cb2be99224d0cdae226760"
-  integrity sha512-4iN6bWrZivT2U5x63t8XJrIQlizkGnxldFdCX5B1YKBrkPUmMq7ffG00Yi+Ahg4WWpCt2TwLoToZMPxz/6tCtw==
+"@bazel/worker@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-3.0.0.tgz#fffe86f9288458de3f990f53a7ad061ad676fa13"
+  integrity sha512-FHZswcd/WrC+Es/6/9ztFfOG3si7GJH74nGB7XTof3cg2ZO3mZC+bZ3rPTuHay+E3FoimPGIwR3qdECMti5PRA==
   dependencies:
     protobufjs "6.8.8"
 


### PR DESCRIPTION
Without this change, rules_sass can not be used in a workspace that is using rules_nodejs 3.0.0

```
error /private/var/tmp/_bazel_dae/4928556feb6f3e9c4d256de8caa46cdd/external/build_bazel_rules_sass_deps/node_modules/@bazel/worker: Command failed.
Exit code: 1
Command: node npm_version_check.js
Arguments:
Directory: /private/var/tmp/_bazel_dae/4928556feb6f3e9c4d256de8caa46cdd/external/build_bazel_rules_sass_deps/node_modules/@bazel/worker
Output:
/private/var/tmp/_bazel_dae/4928556feb6f3e9c4d256de8caa46cdd/external/build_bazel_rules_sass_deps/node_modules/@bazel/worker/npm_version_check.js:17
  throw new Error(`Expected package major version to equal @build_bazel_rules_nodejs major version
  ^

Error: Expected package major version to equal @build_bazel_rules_nodejs major version
    @bazel/worker - 2.3.1
    @build_bazel_rules_nodejs - 3.0.0-rc.0
  See https://github.com/bazelbuild/rules_nodejs/wiki/Avoiding-version-skew
    at Object.<anonymous> (/private/var/tmp/_bazel_dae/4928556feb6f3e9c4d256de8caa46cdd/external/build_bazel_rules_sass_deps/node_modules/@bazel/worker/npm_version_check.js:17:9)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10)
    at internal/main/run_main_module.js:17:11
```