### PR TITLE
Allow `compiler` to be a single file.

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -227,6 +227,7 @@ the input name, so use this attribute with caution.""",
         doc = _COMPILER_ATTR_DOC,
         default = Label("//sass"),
         executable = True,
+        allow_files = True,
         cfg = "host",
     ),
 }


### PR DESCRIPTION
As far as I know this has no downside; upside is it allows `compiler` to be a single binary file, which is useful in google3.