### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,6 +5,11 @@ platforms:
     - "//..."
     test_targets:
     - "//..."
+  ubuntu2004:
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
   macos:
     build_targets:
     - "//..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,20 +1,15 @@
 ---
 platforms:
-  ubuntu1604:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
   ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   macos:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   windows:
     build_targets:
     # Escape hyphens on later args


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.