### PR TITLE
Export bzl_library targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,3 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "defs.bzl",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//sass:bzl",
+    ],
+)

--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "6142e9586162b179fdd570a55e50d1332e7d9c030efd853453438d607569721d",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.0.0/rules_nodejs-3.0.0.tar.gz"],
+        sha256 = "e79c08a488cc5ac40981987d862c7320cee8741122a2649e9b08e850b6f20442",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.8.0/rules_nodejs-3.8.0.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 exports_files([
@@ -21,5 +22,17 @@ nodejs_binary(
     templated_args = [
         "--nobazel_node_patches",
         "--bazel_patch_module_resolver",
+    ],
+)
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "sass.bzl",
+        "sass_repositories.bzl",
+    ],
+    visibility = ["//:__pkg__"],
+    deps = [
+        "@build_bazel_rules_nodejs//:bzl",
     ],
 )

--- a/sass/BUILD
+++ b/sass/BUILD
@@ -10,12 +10,12 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "sass_wrapper",
     data = [
         ":sass_wrapper.js",
-        "@build_bazel_rules_sass_deps//sass",
         "@build_bazel_rules_sass_deps//@bazel/worker",
+        "@build_bazel_rules_sass_deps//sass",
     ],
+    entry_point = "sass_wrapper",
     # Opt-in to the patched require() function like google3 has
     # rules_nodejs 3.0 will flip the default for this flag which breaks rules_sass users
     templated_args = [


### PR DESCRIPTION
As discussed in #135, this is necessary for users wrapping macros/rules defined by rules_sass in their own macros/rules if they want to document them with stardoc.

This is currently blocked on bazelbuild/rules_nodejs#2874, but should hopefully just require a bump of rules_nodejs.