### PR TITLE
build: update to `rules_nodejs` v4 stable to support latest version

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -26,8 +26,8 @@ def rules_sass_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        sha256 = "6142e9586162b179fdd570a55e50d1332e7d9c030efd853453438d607569721d",
-        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.0.0/rules_nodejs-3.0.0.tar.gz"],
+        sha256 = "8a7c981217239085f78acc9898a1f7ba99af887c1996ceb3b4504655383a2c3c",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.0.0/rules_nodejs-4.0.0.tar.gz"],
     )
 
     # Dependencies from the NodeJS rules. We don't want to use the "package.bzl" dependency macro

--- a/sass/package.json
+++ b/sass/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@bazel/worker": "3.0.0",
+    "@bazel/worker": "4.0.0",
     "sass": "1.38.2"
   }
 }

--- a/sass/test/npm_sass_library/test_external_pkg/BUILD
+++ b/sass/test/npm_sass_library/test_external_pkg/BUILD
@@ -4,7 +4,7 @@ js_library(
     name = "test_external_pkg",
     # Special attribute that instructs `js_library` to expose the `ExternalNpmPackageInfo` provider
     # for this library. This emulates an external NPM package installed through `yarn_install`.
-    external_npm_package = True,
+    package_name = "$node_modules$",
     srcs = ["_index.scss", "_other_file.scss", "css_plain.css", "sass_syntax.sass"],
     visibility = ["//sass/test/npm_sass_library:__pkg__"],
 )

--- a/sass/yarn.lock
+++ b/sass/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/worker@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-3.0.0.tgz#fffe86f9288458de3f990f53a7ad061ad676fa13"
-  integrity sha512-FHZswcd/WrC+Es/6/9ztFfOG3si7GJH74nGB7XTof3cg2ZO3mZC+bZ3rPTuHay+E3FoimPGIwR3qdECMti5PRA==
+"@bazel/worker@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-4.0.0.tgz#75ea55f1392f203294151c1bced9b1de017c8c11"
+  integrity sha512-YkATESfezmCWjHYkh2URyJKG25Ps05G4U+QJA76K6ANlGKwYL4J5MbWed0FuRIx/a+0B+bgAFO0BgmcortoZow==
   dependencies:
     protobufjs "6.8.8"
 


### PR DESCRIPTION
`rules_sass` currently relies on the NodeJS Bazel rules for the
build action worker, and for actually building & testing the rules.

This version is currently outdated and especially the dependency
on the outdated `@bazel/worker` package results in errors when
the Sass rules are used with `rules_nodejs` v4.x. e.g.

```
Error: Expected package major version to equal @build_bazel_rules_nodejs major version
    @bazel/worker - 3.0.0
    @build_bazel_rules_nodejs - 4.0.0-beta.0
  See https://github.com/bazelbuild/rules_nodejs/wiki/Avoiding-version-skew
    at Object.<anonymous> (/home/circleci/.cache/bazel/_bazel_circleci/25aa7b3d5096b7e5114a3cf6c0d4a5bf/external/build_bazel_rules_sass_deps/_/sass/node_modules/@bazel/worker/npm_version_check.js:17:9)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10)
    at internal/main/run_main_module.js:17:11
)
ERROR: Error fetching repository: Traceback (most recent call last):
```

Fixing this would allow us to remove various workarounds for this in the Angular organization.