### PR TITLE
Support for vendored Yarn to be provided when Sass dependencies are installed

### DIFF
--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -21,7 +21,7 @@ def sass_repositories(yarn_script = None):
 
       Args:
         yarn_script: Optional path to a Yarn CLI JavaScript file. This can be useful when
-          Yarn is vendored. The Sass rules rely on a `yarn_install` for its depdendencies.
+          Yarn is vendored. The Sass rules rely on a `yarn_install` for its dependencies.
     """
 
     yarn_install(

--- a/sass/sass_repositories.bzl
+++ b/sass/sass_repositories.bzl
@@ -16,8 +16,14 @@
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
-def sass_repositories():
-    """Set up environment for Sass compiler."""
+def sass_repositories(yarn_script = None):
+    """Set up environment for Sass compiler.
+
+      Args:
+        yarn_script: Optional path to a Yarn CLI JavaScript file. This can be useful when
+          Yarn is vendored. The Sass rules rely on a `yarn_install` for its depdendencies.
+    """
+
     yarn_install(
         name = "build_bazel_rules_sass_deps",
         package_json = "@io_bazel_rules_sass//sass:package.json",
@@ -26,4 +32,5 @@ def sass_repositories():
         # node_modules folders in the @io_bazel_rules_sass external repository. This is
         # not supported by managed_directories.
         symlink_node_modules = False,
+        yarn = yarn_script,
     )


### PR DESCRIPTION
As of Bazel v5, the `@yarn//` repository is not necessarily required anymore,
and developers are free to provide a regular file to be used as Yarn script.

It's not trivial to wire such a regular file/script as repository that behaved
similar to the old `@yarn//` repository. Since the Sass Bazel rules rely on a
Yarn install (as a side note: which is something that is likely not necessary),
we should allow users to provide the path to Yarn (when vendored).

We could have exposed a pass-through for all Yarn install options but there seems
to be no other useful argument that consumers should have access to, and it would
make this function/definition a little more unintuitive.

FYI: Also sent a PR to fix buildkite in the `main` branch: https://github.com/bazelbuild/continuous-integration/pull/1350