### PR TITLE
fix: add missing extension to sass entrypoint

### DIFF
--- a/sass/BUILD
+++ b/sass/BUILD
@@ -11,7 +11,7 @@ exports_files([
 # Executable for the sass_binary rule
 nodejs_binary(
     name = "sass",
-    entry_point = "sass_wrapper",
+    entry_point = "sass_wrapper.js",
     data = [
         ":sass_wrapper.js",
         "@build_bazel_rules_sass_deps//sass",


### PR DESCRIPTION
This bug is surfaced in https://github.com/bazelbuild/rules_nodejs/pull/3495 where we remove a legacy wrapper script around a the entry point of a nodejs_binary. The entry point path is now resolved with `rlocation` which causes an error when the extension is missing.