### PR TITLE
Add SassInfo to sass_binary.

### DIFF
--- a/sass/sass.bzl
+++ b/sass/sass.bzl
@@ -125,7 +125,14 @@ def _sass_binary_impl(ctx):
         outputs = [ctx.outputs.css_file]
 
     _run_sass(ctx, ctx.file.src, ctx.outputs.css_file, map_file)
-    return DefaultInfo(runfiles = ctx.runfiles(files = outputs))
+    transitive_sources = _collect_transitive_sources(
+        [ctx.file.src],
+        ctx.attr.deps,
+    )
+    return [
+        SassInfo(transitive_sources = transitive_sources),
+        DefaultInfo(runfiles = ctx.runfiles(files = outputs)),
+    ]
 
 def _sass_binary_outputs(src, output_name, output_dir, sourcemap):
     """Get map of sass_binary outputs, including generated css and sourcemaps.


### PR DESCRIPTION
This is so you can include a sass_binary in the deps of another sass_binary.

for example:
```starlark
sass_binary(
  name = "a_sass",
  src = "a.scss",
)
sass_binary(
  name = "b_sass",
  src = "b.scss",
)
```
Where b.scss is:
```sass
@forward "./a";
```

I'm trying to write bazel rules for material-components-web, and they seem to do this a lot. For example, https://github.com/material-components/material-components-web/tree/master/packages/mdc-ripple